### PR TITLE
Add sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 # Travis CI
+sudo: required
+
 language: node_js
 
 cache:


### PR DESCRIPTION
> THE CONTENT OF THIS PR IS WRONG. SEE CORRECTION IN #9!

Using automatic deployment to Heroku isn't possible with the Travis CI "container-based" infrastructure, because Heroku depends on gems, which requires sudo.
#### Helpful resources
- https://github.com/travis-ci/travis-ci/issues/5033#issuecomment-152545073
- http://stackoverflow.com/questions/26299552/travis-sudo-is-disabled
- http://stackoverflow.com/questions/33437022/how-do-i-automatically-deploy-from-travis-ci-with-the-container-based-infrastruc
